### PR TITLE
Save report output to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ grunt.initConfig({
       directory: ['**/*.handlebars', '**/*.html'],
       days: 30,
       remove: false, // set to true to delete unused files from project
-      reportOutput:'report.txt', // set to false to disable file output
+      reportOutput:'report.txt' // set to false to disable file output
     }
   }
 });

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ grunt.initConfig({
       reference: 'img/',
       directory: ['**/*.handlebars', '**/*.html'],
       days: 30,
-      remove: false // set to true to delete unused files from project
+      remove: false, // set to true to delete unused files from project
+      reportOutput:'report.txt', // set to false to disable file output
     }
   }
 });
@@ -74,6 +75,12 @@ Type: `Number`
 Default value: `false`
 
 If remove is set to true and days has a value files will only delete if the file hasn't been modified after the length of days.
+
+#### reportOutput
+Type: `String`
+Default value: `false`
+
+Output unused files to a file. Set to false to disable
 
 ## Release History
 * 0.1.9: Add jshint and jsonlint tests.

--- a/tasks/unused.js
+++ b/tasks/unused.js
@@ -139,7 +139,7 @@ module.exports = function (grunt) {
       if (!grunt.file.exists(destDir)) {
         grunt.file.mkdir(destDir);
       }
-      grunt.file.write(options.reportOutput,unused.join("\r\n"));
+      grunt.file.write(options.reportOutput,unused.join('\r\n'));
       grunt.log.ok('Report "' + options.reportOutput + '" created.');
     }
   });

--- a/tasks/unused.js
+++ b/tasks/unused.js
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Ryan Burgess
  * Licensed under the MIT license.
  */
+var path = require('path');
 module.exports = function (grunt) {
   'use strict';
   grunt.registerTask('unused', function(){
@@ -27,7 +28,8 @@ module.exports = function (grunt) {
       reference: 'img/',
       directory: ['**/*.html'],
       remove: false,
-      days: null
+      days: null,
+      reportOutput:false
     });
 
     //get current date and time
@@ -131,5 +133,14 @@ module.exports = function (grunt) {
         logFiles(options.reference + file);
       }
     });
+
+    if (unused.length > 0 && options.reportOutput) {
+      var destDir = path.dirname(options.reportOutput);
+      if (!grunt.file.exists(destDir)) {
+        grunt.file.mkdir(destDir);
+      }
+      grunt.file.write(options.reportOutput,unused.join("\r\n"));
+      grunt.log.ok('Report "' + options.reportOutput + '" created.');
+    }
   });
 };


### PR DESCRIPTION
Ability to generate plain text report output to a file. Add reportOutput:’dest’ to export output to a specific file. reportOutput:false to disable. Default:false