### PR TITLE
Add `fail` option to make the task fail when unused files are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ grunt.initConfig({
       directory: ['**/*.handlebars', '**/*.html'],
       days: 30,
       remove: false, // set to true to delete unused files from project
-      reportOutput:'report.txt' // set to false to disable file output
+      reportOutput:'report.txt', // set to false to disable file output
+      fail: false // set to true to make the task fail when unused files are found
     }
   }
 });
@@ -68,7 +69,7 @@ An array of directories that contain files that reference files in the reference
 Type: `Boolean`
 Default value: `false`
 
-The ablity to automatically delete unused file reference from project.
+The ability to automatically delete unused file reference from project.
 
 #### days
 Type: `Number`
@@ -81,6 +82,12 @@ Type: `String`
 Default value: `false`
 
 Output unused files to a file. Set to false to disable
+
+### fail
+Type: `Boolean`
+Default value: `false`
+
+Allows the Grunt task to fail when unused files are found.
 
 ## Release History
 * 0.2.1: Merge pull request [#5](https://github.com/ryanburgess/grunt-unused/pull/5)

--- a/tasks/unused.js
+++ b/tasks/unused.js
@@ -29,7 +29,8 @@ module.exports = function (grunt) {
       directory: ['**/*.html'],
       remove: false,
       days: null,
-      reportOutput:false
+      reportOutput: false,
+      fail: false
     });
 
     //get current date and time
@@ -147,6 +148,10 @@ module.exports = function (grunt) {
       }
       grunt.file.write(options.reportOutput,unused.join('\r\n'));
       grunt.log.ok('Report "' + options.reportOutput + '" created.');
+    }
+
+    if (unused.length && !options.remove && options.fail) {
+      grunt.fail.warn('Unused files were found.');
     }
   });
 };

--- a/tasks/unused.js
+++ b/tasks/unused.js
@@ -105,8 +105,14 @@ module.exports = function (grunt) {
 
     // Output unused files list in console
     unused = grunt.util._.difference(assets, links);
+
     // output number of unused files
-    grunt.log.ok(unused.length + ' file' + (unused.length === 1 ? '' : 's') + ' unused files:');
+    if (unused.length) {
+      grunt.log.warn(unused.length + ' unused file' + (unused.length === 1 ? '' : 's') + ':');
+    }
+    else {
+      grunt.log.ok('No unused files found.');
+    }
 
     unused.forEach(function(file){
       


### PR DESCRIPTION
Messages have been fixed a little as well.

It will fail only when unused files are found, the `fail` option is `true`, and the `remove` option is `false`.