### PR TITLE
add option to exclude an array of strings (partial match)

### DIFF
--- a/tasks/unused.js
+++ b/tasks/unused.js
@@ -31,7 +31,8 @@ module.exports = function (grunt) {
       remove: false,
       days: null,
       reportOutput: false,
-      fail: false
+      fail: false,
+      exclude: []
     });
 
     //get current date and time
@@ -107,6 +108,11 @@ module.exports = function (grunt) {
 
     // Output unused files list in console
     unused = _.difference(assets, links);
+
+    options.exclude.map((ex) => {
+      unused = _.filter(unused, (_unused) => !_unused.includes(ex));
+    });
+
 
     // output number of unused files
     if (unused.length) {


### PR DESCRIPTION
I'm using retina.js on a project so I'm not explicitly requesting @2x or @3x versions of images in my files. 

Pull request adds an option to exclude a partial string from results, for example

```
exclude: ["@2x", "@3x"]
```